### PR TITLE
Fix OTA config bug

### DIFF
--- a/Enviro-SHT31D.yaml
+++ b/Enviro-SHT31D.yaml
@@ -37,8 +37,7 @@ api:
 # Over-the-Air Updates
 # -------------------------------
 ota:
-  - platform: esphome
-    password: !secret enviro1_ota_pwd  # OTA update password (stored in secrets.yaml)
+  password: !secret enviro1_ota_pwd  # OTA update password (stored in secrets.yaml)
 
 # -------------------------------
 # Time Synchronization

--- a/README.md
+++ b/README.md
@@ -1,1 +1,8 @@
-# ESP32_ESPhome_Temp-Humidity-SHT31D
+# ESP32 SHT31D Environment Sensor
+
+This repository contains an [ESPHome](https://esphome.io/) configuration for an
+ESP32 based temperature and humidity monitor using the SHT31D sensor. The
+configuration exposes readings to Home Assistant and includes WiFi and OTA
+setup.  Calibration values and network credentials are expected to be provided
+via `secrets.yaml`.
+


### PR DESCRIPTION
## Summary
- fix OTA password block in ESPhome config
- add a basic README with repo purpose

## Testing
- `pip install --user yamllint` *(fails: cannot connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68747bbdb80483319519696979093860