### PR TITLE
Fix WiFi switch label

### DIFF
--- a/Enviro-SHT31D.yaml
+++ b/Enviro-SHT31D.yaml
@@ -131,7 +131,7 @@ binary_sensor:
 # -------------------------------
 switch:
   - platform: gpio
-    name: "Wifi Connect LED Switch"    # Controls onboard LED (GPIO2)
+    name: "WiFi Connect LED Switch"    # Controls onboard LED (GPIO2)
     pin: 2
     id: onboard_led
     inverted: false                    # Set to true if LED logic is inverted


### PR DESCRIPTION
## Summary
- correct the WiFi switch name in `Enviro-SHT31D.yaml`

## Testing
- `git diff --color Enviro-SHT31D.yaml | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_687542478c5c833188347d793633f07e