### PR TITLE
Fix uptime sensor reference

### DIFF
--- a/enviro-a1.yaml
+++ b/enviro-a1.yaml
@@ -119,7 +119,7 @@ sensor:
 
   # How long the device has been running
   - platform: uptime
-    id: enviro_b1_uptime_sensor
+    id: enviro_a1_uptime_sensor
     name: "ENVIRO-A1 Uptime"
 
 binary_sensor:


### PR DESCRIPTION
## Summary
- update uptime sensor ID in `enviro-a1.yaml`
- keep reboot trigger lambda in sync

## Testing
- `yamllint enviro-a1.yaml` *(fails: various lint warnings/errors)*

------
https://chatgpt.com/codex/tasks/task_e_6880ff6f208483319b7d83c9e0bd7502